### PR TITLE
Implement base_path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Alternatively, you can pass `false` as the only argument to `.slashes()` in orde
 .use(slashes(false));
 ``` 
 
+If an application is behind a reverse proxy server that removes part of the URL (a base_path) before proxying to the application, then the base_path must can be specified with an option:
+
+```javascript
+.use(slashes({append: false, base_path: '/blog'}));
+```
+
 ## Notes
 
 1. Only GET requests will be redirected (to avoid losing POST/PUT data)

--- a/lib/connect-slashes.js
+++ b/lib/connect-slashes.js
@@ -32,6 +32,11 @@ var reQuery = /[\?\&]+/;
 var reAbsolute = /^(\/\/+)/;
 
 var slashes = function( append ) {
+    var base_path;
+    if (append instanceof Object) {
+	base_path = append.base_path;
+	append = append.append;
+    }
     ( append === false ) || ( append = true ); // default to append slashes mode
 
     return function( req, res, next ) {
@@ -61,6 +66,9 @@ var slashes = function( append ) {
                 if ( url.length > 1 ) {
                     redirect += "?" + url.slice( 1 ).join( "&" );
                 }
+		if (base_path) {
+		    redirect = base_path + redirect;
+		}
 
                 res.writeHead( 301, { "Location": redirect } );
                 res.end();


### PR DESCRIPTION
implements a base_path option for use behind reverse proxy servers with URI routing.  Fixes #4
