### PR TITLE
Add headers option and accompanying test

### DIFF
--- a/lib/connect-slashes.js
+++ b/lib/connect-slashes.js
@@ -40,7 +40,8 @@ var slashes = function( append, options ) {
         if ( "GET" == req.method ) {
             var url = req.url.split( reQuery )
               , location = url[ 0 ]
-              , redirect;
+              , redirect
+              , headers;
 
             if ( append && "/" != location[ location.length - 1 ] ) {
 
@@ -67,7 +68,10 @@ var slashes = function( append, options ) {
                     redirect = "/" + redirect; // guarantee absolute redirect
                 }
 
-                res.writeHead( options.code || 301, { "Location": redirect } );
+                headers = options.headers || {};
+                headers[ "Location" ] = redirect;
+
+                res.writeHead( options.code || 301, headers );
                 res.end();
                 return;
             }

--- a/test/connect-slashes.js
+++ b/test/connect-slashes.js
@@ -1,5 +1,5 @@
 var slashes = require( ".." ),
-    assert = require( "assert" )
+    assert = require( "assert" ),
     http = require( "http" );
 
 var append = slashes( true );
@@ -130,6 +130,19 @@ describe( "connect-slashes", function() {
         }, function() {
             assert( false ); // no redirect took place
         });
+    });
+
+    it( "should set headers", function( done ) {
+        slashes( true, { headers: { "Cache-Control": "public" } } )( { method: "GET", url: "/foo" }, {
+            writeHead: function( status, headers ) {
+                assert( "public" == headers["Cache-Control"] );
+                assert( "/foo/" == headers.Location );
+            },
+            end: done
+
+        }, function() {
+            assert( false ); // no redirect took place
+        } );
     });
 
 } );


### PR DESCRIPTION
PR for issue #7

Uses and modifies a header object, rather than `res.set` as this seemed a better fit & was easier to test.

I've tried to keep in style with the rest of the code.
