### PR TITLE
Add Express compatibility.

### DIFF
--- a/lib/connect-slashes.js
+++ b/lib/connect-slashes.js
@@ -38,7 +38,8 @@ var slashes = function( append, options ) {
     return function( req, res, next ) {
 
         if ( "GET" == req.method ) {
-            var url = req.url.split( reQuery )
+            // Use originalUrl when defined ( for express compatibility);
+            var url = (req.originalUrl || req.url).split( reQuery )
               , location = url[ 0 ]
               , redirect
               , headers;

--- a/test/connect-slashes.js
+++ b/test/connect-slashes.js
@@ -37,8 +37,32 @@ describe( "connect-slashes", function() {
     });
 
     //
+    it( "should append slashes for GET requests using originalUrl", function( done ) {
+        append( { method: "GET", originalUrl: "/foo" }, {
+            writeHead: function( status, headers ) {
+                assert( "/foo/" == headers.Location );
+            },
+            end: done
+        }, function() {
+            assert( false ); // no redirect took place
+        } );
+    });
+
+    //
     it( "should remove slashes", function( done ) {
         slashes( false )( { method: "GET", url: "/foo/" }, {
+            writeHead: function( status, headers ) {
+                assert( "/foo" == headers.Location );
+            },
+            end: done
+        }, function() {
+            assert( false ); // no redirect took place
+        } );
+    });
+
+    //
+    it( "should remove slashes when using originalUrl", function( done ) {
+        slashes( false )( { method: "GET", originalUrl: "/foo/" }, {
             writeHead: function( status, headers ) {
                 assert( "/foo" == headers.Location );
             },


### PR DESCRIPTION
In Express, if you mount middleware that uses connect-slashes url is not always representative of actual request url.  For instance:

`app.use('/root', myMiddleWareUsingSlashes());`

Will see '/' as the url when a user requests '/root' but originalUrl will show '/root'.
