### PR TITLE
support HEAD requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can also set additional headers to the redirect response with the `headers` 
 
 ## Notes
 
-1. Only GET requests will be redirected (to avoid losing POST/PUT data)
+1. Only GET, HEAD, and OPTIONS requests will be redirected (to avoid losing POST/PUT data)
 2. This middleware will append or remove a trailing slash to all request urls. This includes filenames (/app.css => /app.css/), so it may break your static files. Make sure to `.use()` this middleware only after the `connect.static()` middleware.
 
 ## LICENSE

--- a/lib/connect-slashes.js
+++ b/lib/connect-slashes.js
@@ -37,7 +37,7 @@ var slashes = function( append, options ) {
 
     return function slashes( req, res, next ) {
 
-        if ( "GET" == req.method || "HEAD" == req.method ) {
+        if ( "GET" == req.method || "HEAD" == req.method || "OPTIONS" == req.method ) {
             // Use originalUrl when defined ( for express compatibility);
             var url = (req.originalUrl || req.url).split( reQuery )
               , location = url[ 0 ]

--- a/lib/connect-slashes.js
+++ b/lib/connect-slashes.js
@@ -37,7 +37,7 @@ var slashes = function( append, options ) {
 
     return function slashes( req, res, next ) {
 
-        if ( "GET" == req.method ) {
+        if ( "GET" == req.method || "HEAD" == req.method ) {
             // Use originalUrl when defined ( for express compatibility);
             var url = (req.originalUrl || req.url).split( reQuery )
               , location = url[ 0 ]

--- a/test/connect-slashes.js
+++ b/test/connect-slashes.js
@@ -37,6 +37,18 @@ describe( "connect-slashes", function() {
     });
 
     //
+    it( "should append slashes for HEAD requests", function( done ) {
+        append( { method: "HEAD", url: "/foo" }, {
+            writeHead: function( status, headers ) {
+                assert( "/foo/" == headers.Location );
+            },
+            end: done
+        }, function() {
+            assert( false ); // no redirect took place
+        } );
+    });
+
+    //
     it( "should append slashes for GET requests using originalUrl", function( done ) {
         append( { method: "GET", originalUrl: "/foo" }, {
             writeHead: function( status, headers ) {

--- a/test/connect-slashes.js
+++ b/test/connect-slashes.js
@@ -49,6 +49,18 @@ describe( "connect-slashes", function() {
     });
 
     //
+    it( "should append slashes for OPTIONS requests", function( done ) {
+        append( { method: "OPTIONS", url: "/foo" }, {
+            writeHead: function( status, headers ) {
+                assert( "/foo/" == headers.Location );
+            },
+            end: done
+        }, function() {
+            assert( false ); // no redirect took place
+        } );
+    });
+
+    //
     it( "should append slashes for GET requests using originalUrl", function( done ) {
         append( { method: "GET", originalUrl: "/foo" }, {
             writeHead: function( status, headers ) {


### PR DESCRIPTION
Hi @avinoamr 👋 

This PR adds support for `HEAD` requests, mimicking the existing behavior of `GET` requests.

This might help resolve https://github.com/stevenvachon/broken-link-checker/issues/119#issuecomment-470745489

Resolves #12 